### PR TITLE
ROWY-863: add version endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN npm install --production
 COPY --from=builder /home/node/app/build ./build
 
 EXPOSE 8080
-CMD [ "node", "build/index.js" ]
+CMD [ "node", "build/src/index.js" ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ import { hasAnyRole, requireAuth } from "./middleware/auth.js";
 import { configPublisher } from "./publisher.js";
 import { consumer } from "./consumer.js";
 import rowyRedirect from "./rowyRedirect.js";
-//import { metadataService } from './metadataService.js';
+import { version } from "./utils/version.js";
+
 const app = express.default();
 // json is the default content-type for POST requests
 const rawBodySaver = (
@@ -54,6 +55,9 @@ const functionWrapper =
 
 // redirect /
 app.get("/", rowyRedirect);
+
+// Version
+app.get("/version", functionWrapper(version));
 
 // Webhooks
 app.post(

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,0 +1,3 @@
+import meta from "../../package.json" assert { type: "json" };
+
+export const version = async () => ({ version: meta.version });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     // "sourceMap": true,                           /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */
     "outDir": "build" /* Redirect output structure to the directory. */,
-    "rootDir": "src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
+    "rootDir": "." /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
     // "composite": true,                           /* Enable project compilation */
     // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
     // "removeComments": true,                      /* Do not emit comments to output. */
@@ -67,6 +67,8 @@
 
     /* Advanced Options */
     "skipLibCheck": true /* Skip type checking of declaration files. */,
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
+
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
Had to change rootDir from "./src" to "." so the package file could be included in the build folder. Seems like functioning as expected.

<img width="222" alt="Screenshot 2023-01-13 at 12 30 40" src="https://user-images.githubusercontent.com/34177142/212216414-d715b444-d316-4050-baad-b3f214ec0875.png">

[JSON type assertion](https://github.com/tc39/proposal-import-assertions) is a new syntax.