### PR TITLE
add table schema to context

### DIFF
--- a/src/utils/rowySettings.ts
+++ b/src/utils/rowySettings.ts
@@ -1,0 +1,18 @@
+import { db } from "../firebaseConfig.js";
+
+export const ROWY_SETTINGS = "_rowy_/settings";
+export const TABLE_SCHEMAS = "_rowy_/settings/schema";
+
+export const getTableSchema = (tablePath: string) => () =>
+  db
+    .doc(
+      [
+        TABLE_SCHEMAS,
+        tablePath
+          .split("/")
+          .map((segment, i) => (i % 2 === 0 ? segment : "subTables"))
+          .join("/"),
+      ].join("/")
+    )
+    .get()
+    .then((snapshot) => snapshot.data());


### PR DESCRIPTION
Usage in webhooks:
```typescript
const basicParser: Parser = async ({ req, db, ref, logging, auth, res, tableSchema }) => {
  const schemaDoc = await tableSchema.get();
  return res.send({ schema: schemaDoc });
}
```

Note: As opposed to current usage in functions which uses fetched schema during build stage, I wanted to make it a async call just like accessing secrets.